### PR TITLE
Introduced 'whenever' helper for automating crontab updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "http://rubygems.org"
 gem "capistrano"
 gem "railsless-deploy", :require => :nil
 gem "capistrano_rsync_with_remote_cache"
+gem 'whenever', :require => false
 
 gem "cucumber", :group => :development
 gem "rspec", :group => :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,13 @@
 GEM
   remote: http://rubygems.org/
   specs:
+    activesupport (4.1.6)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
+    builder (3.2.2)
     capistrano (2.15.5)
       highline
       net-scp (>= 1.0.0)
@@ -9,7 +16,22 @@ GEM
       net-ssh-gateway (>= 1.1.0)
     capistrano_rsync_with_remote_cache (2.4.0)
       capistrano (>= 2.1.0)
+    chronic (0.10.2)
+    cucumber (1.3.17)
+      builder (>= 2.1.2)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 2.12)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.1)
+    diff-lcs (1.2.5)
+    gherkin (2.12.2)
+      multi_json (~> 1.3)
     highline (1.6.19)
+    i18n (0.6.11)
+    json (1.8.1)
+    minitest (5.4.1)
+    multi_json (1.10.1)
+    multi_test (0.1.1)
     net-scp (1.1.2)
       net-ssh (>= 2.6.5)
     net-sftp (2.1.2)
@@ -18,6 +40,24 @@ GEM
     net-ssh-gateway (1.2.0)
       net-ssh (>= 2.6.5)
     railsless-deploy (1.1.2)
+    rspec (3.1.0)
+      rspec-core (~> 3.1.0)
+      rspec-expectations (~> 3.1.0)
+      rspec-mocks (~> 3.1.0)
+    rspec-core (3.1.4)
+      rspec-support (~> 3.1.0)
+    rspec-expectations (3.1.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.1.0)
+    rspec-mocks (3.1.1)
+      rspec-support (~> 3.1.0)
+    rspec-support (3.1.0)
+    thread_safe (0.3.4)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
+    whenever (0.9.2)
+      activesupport (>= 2.3.4)
+      chronic (>= 0.6.3)
 
 PLATFORMS
   ruby
@@ -25,4 +65,7 @@ PLATFORMS
 DEPENDENCIES
   capistrano
   capistrano_rsync_with_remote_cache
+  cucumber
   railsless-deploy
+  rspec
+  whenever

--- a/lib/shipistrano/helpers/whenever.rb
+++ b/lib/shipistrano/helpers/whenever.rb
@@ -1,0 +1,13 @@
+#
+# Whenever is a tool for automating the setup of cron jobs (and runner etc).
+# https://github.com/javan/whenever
+# 
+# Note: The whenever gem must be installed on the dev machine, and the server.
+# 
+# Usage: Include a config/schedule.rb file in your project root.
+# See the example on github for format.
+#
+
+set :whenever_identifier, "#{app}"
+set :whenever_roles, [:web]
+require "whenever/capistrano"


### PR DESCRIPTION
Hey guys,  figure you might find this helper handy.
Makes use of the [whenever](https://github.com/javan/whenever) gem. (needs to be on local, and server)

Be careful of conflicts of gemfile / lockfile when merging - I haven't updated my master branch for a while.

With a `config/schedule.rb` file in your project root:

``` ruby
every "5 0 * * *" do
    command "/home/www/sites/website.co.nz/current/framework/sake dev/tasks/GeneratedImageCacheControlTask"
end
every "0 * * * *" do
    command "/home/www/sites/website.co.nz/current/framework/sake dev/tasks/CalculateProductPopularity"
end
every "2 * * * *" do
    command "/home/www/sites/website.co.nz/current/framework/sake dev/tasks/CalculateSubShopPopularity"
end
```

Crontab will look like this:

```

# Begin Whenever generated tasks for: website.co.nz
5 0 * * * /bin/bash -l -c '/home/www/sites/website.co.nz/current/framework/sake dev/tasks/GeneratedImageCacheControlTask'

0 * * * * /bin/bash -l -c '/home/www/sites/website.co.nz/current/framework/sake dev/tasks/CalculateProductPopularity'

2 * * * * /bin/bash -l -c '/home/www/sites/website.co.nz/current/framework/sake dev/tasks/CalculateSubShopPopularity'

# End Whenever generated tasks for: website.co.nz


```

Any changes you make, and re-deploy, will update the appropriate section of crontab.
